### PR TITLE
Update link to Jaxley documentation

### DIFF
--- a/docs/source/tutorials/tutorial_referencing.rst
+++ b/docs/source/tutorials/tutorial_referencing.rst
@@ -12,7 +12,7 @@ The following simulatord are currently supported:
 
 Planned support for the following simulators:
 
-- `Jaxley <https://jaxleyverse.github.io/jaxley>`_
+- `Jaxley <https://jaxley.readthedocs.io/en/latest/>`_
 
 .. tip::
 


### PR DESCRIPTION
Hyperlink pointed to old Jaxley docs. This fixes it.